### PR TITLE
Build arm image and other improvements

### DIFF
--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -11,7 +11,7 @@ steps:
   dryrun:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
       dry_run: true
       repo: woodpeckerci/plugin-codecov
       tag: test
@@ -21,7 +21,7 @@ steps:
   publish-next:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
       repo: woodpeckerci/plugin-codecov
       tags: next
     secrets: [docker_username, docker_password]
@@ -32,7 +32,7 @@ steps:
   publish-tag:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
       auto_tag: true
       platforms: *platforms
       repo: woodpeckerci/plugin-codecov

--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -1,8 +1,17 @@
+when:
+  - event: [pull_request, tag, cron]
+  - event: push
+    branch:
+      - ${CI_REPO_DEFAULT_BRANCH}
+
+variables:
+  - &platforms "linux/amd64,linux/arm64"
+
 steps:
   dryrun:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile.alpine
+      dockerfile: docker/Dockerfile
       dry_run: true
       repo: woodpeckerci/plugin-codecov
       tag: test
@@ -12,7 +21,7 @@ steps:
   publish-next:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile.alpine
+      dockerfile: docker/Dockerfile
       repo: woodpeckerci/plugin-codecov
       tags: next
     secrets: [docker_username, docker_password]
@@ -23,9 +32,10 @@ steps:
   publish-tag:
     image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
-      dockerfile: docker/Dockerfile.alpine
+      dockerfile: docker/Dockerfile
+      auto_tag: true
+      platforms: *platforms
       repo: woodpeckerci/plugin-codecov
-      tags: [latest, "${CI_COMMIT_TAG##v}"]
     secrets: [docker_username, docker_password]
     when:
       event: tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.21 AS build
 
+# renovate: datasource=github-releases depName=codecov/uploader
+ARG UPLOADER_VERSION=0.1.17
+
 WORKDIR /src
 COPY . .
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN curl -Os https://uploader.codecov.io/v0.1.17/alpine/codecov
+RUN curl -Os https://uploader.codecov.io/v${CODECOV_UPLOADER_VERSION}/alpine/codecov
 RUN chmod +x codecov
 
 FROM alpine:3.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,18 @@ ARG UPLOADER_VERSION=v0.6.2
 
 WORKDIR /src
 COPY . .
+#
+RUN apk add -U --no-cache ca-certificates
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
 RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
 RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
 RUN chmod +x codecov && mv codecov /bin/ && mv plugin-codecov /bin/
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build src/codecov /bin/
+COPY --from=build src/plugin-codecov /bin/
 
 ENTRYPOINT ["/bin/plugin-codecov"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG UPLOADER_VERSION=v0.6.2
 WORKDIR /src
 COPY . .
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 codecov; fi
-RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine codecov; fi
+RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
+RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
 RUN chmod +x codecov
 
 FROM alpine:3.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG UPLOADER_VERSION=v0.6.2
 WORKDIR /src
 COPY . .
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN if [ $(arch) = "aarch64" ] ; then curl -Os https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64; fi
-RUN if [ $(arch) = "x86_64" ] ; then curl -Os https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine; fi
+RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 codecov; fi
+RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine codecov; fi
 RUN chmod +x codecov
 
 FROM alpine:3.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as build
+FROM golang:1.21-alpine as build
 
 # renovate: datasource=github-releases depName=codecov/uploader
 ARG UPLOADER_VERSION=v0.6.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1.21 AS build
 
 # renovate: datasource=github-releases depName=codecov/uploader
-ARG UPLOADER_VERSION=0.1.17
+ARG UPLOADER_VERSION=v0.6.2
 
 WORKDIR /src
 COPY . .
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN curl -Os https://uploader.codecov.io/v${CODECOV_UPLOADER_VERSION}/alpine/codecov
+RUN if [ $(arch) = "aarch64" ] ; then curl -Os https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64; fi
+RUN if [ $(arch) = "x86_64" ] ; then curl -Os https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine; fi
 RUN chmod +x codecov
 
 FROM alpine:3.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.21
 
 # renovate: datasource=github-releases depName=codecov/uploader
 ARG UPLOADER_VERSION=v0.6.2
@@ -8,12 +8,7 @@ COPY . .
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
 RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
 RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
-RUN chmod +x codecov
-
-FROM alpine:3.18
-RUN apk add -U --no-cache ca-certificates
-
-COPY --from=build src/codecov /bin/
-COPY --from=build src/plugin-codecov /bin/
+RUN chmod +x codecov && mv codecov /bin/ && mv plugin-codecov /bin/
 
 ENTRYPOINT ["/bin/plugin-codecov"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG UPLOADER_VERSION=v0.6.2
 WORKDIR /src
 COPY . .
 #
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -q --no-cache ca-certificates curl
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
 RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
 RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add -U --no-cache ca-certificates
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
 RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
 RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
-RUN chmod +x codecov && mv codecov /bin/ && mv plugin-codecov /bin/
+RUN chmod +x codecov plugin-codecov
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.21 as build
 
 # renovate: datasource=github-releases depName=codecov/uploader
 ARG UPLOADER_VERSION=v0.6.2

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
+  "extends": ["github>woodpecker-ci/renovate-config"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
   ]
 }


### PR DESCRIPTION
- versionize uploader version via `renovate`
- Build arm image
- Avoid duplicate workflow runs
- auto tag images on tag event
- use scratch image instead of alpine

Relates to https://github.com/woodpecker-ci/woodpecker/pull/2232