### PR TITLE
Fix codecov binary download: follow links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY . .
 #
 RUN apk add -q --no-cache ca-certificates curl
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN if [ $(arch) = "aarch64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
-RUN if [ $(arch) = "x86_64" ] ; then curl -s https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
+RUN if [ $(arch) = "aarch64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
+RUN if [ $(arch) = "x86_64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-linux -o codecov; fi
 RUN chmod +x codecov plugin-codecov
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 #
 RUN apk add -q --no-cache ca-certificates curl
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
-RUN if [ $(arch) = "aarch64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
+RUN if [ $(arch) = "aarch64" ] ; then curl -sLf https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
 RUN if [ $(arch) = "x86_64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
 RUN chmod +x codecov plugin-codecov
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN apk add -q --no-cache ca-certificates curl
 RUN go build -ldflags '-s -w -extldflags "-static"' -o plugin-codecov
 RUN if [ $(arch) = "aarch64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-aarch64 -o codecov; fi
-RUN if [ $(arch) = "x86_64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-linux -o codecov; fi
+RUN if [ $(arch) = "x86_64" ] ; then curl -sL https://github.com/codecov/uploader/releases/download/${UPLOADER_VERSION}/codecov-alpine -o codecov; fi
 RUN chmod +x codecov plugin-codecov
 
 FROM scratch


### PR DESCRIPTION
In 2.1.0 the binaries were not actually downloaded but `curl` also doesn't thrown an error if this happens.